### PR TITLE
Fix Vercel preview CI: bump Node to 24 (pnpm 11 requires Node ≥22)

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -66,7 +66,7 @@ jobs:
           git checkout -b design-tokens-preview-${{ github.sha }}
 
       - name: Install Vercel CLI
-        run: pnpm i -g vercel@latest
+        run: npm i -g vercel@latest
 
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Why

The `Vercel Preview Deployment` check has been failing on every PR (e.g. #92). Two pieces of CI had rotted because settle-web's toolchain moved forward while this workflow stayed pinned to old versions.

### Failure 1 — pnpm install crashes on Node 20

```
warn: This version of pnpm requires at least Node.js v22.13
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
```

This workflow checks out **settle-web** at the root, so `pnpm/action-setup` resolves pnpm from settle-web's `package.json` → `"packageManager": "pnpm@11.1.1"`. pnpm 11 requires **Node ≥ 22.13** and `require('node:sqlite')` (built-in only from Node 22.5+). settle-web has since moved `engines.node` to `24.x`, but this workflow stayed at `node-version: 20.x`.

**Fix:** `node-version: 20.x` → `24.x` (matches settle-web's engine).

### Failure 2 — global Vercel CLI install (surfaced once install was reachable)

```
[ERROR] The configured global bin directory ".../node_modules/.bin/bin" is not in PATH
```

Modern pnpm refuses `pnpm i -g` unless its global bin dir is on `PATH`. 

**Fix:** install the CLI with `npm i -g vercel@latest` instead — `actions/setup-node` already puts npm's global bin on PATH.

## Result

Both previously-failing steps now pass (Install dependencies ✅, Install Vercel CLI ✅, Pull Vercel Env ✅); the job proceeds to the real Vercel build.

---
Linear: [STL-3769](https://linear.app/settle/issue/STL-3769)
