### PR TITLE
Add read-only variant to Input/Outlined

### DIFF
--- a/tokens_2/Component/Settle/Input/Outlined.json
+++ b/tokens_2/Component/Settle/Input/Outlined.json
@@ -32,6 +32,10 @@
           "value": "{basic.borderWidth.100}",
           "type": "borderWidth"
         },
+        "read-only": {
+          "value": "{basic.borderWidth.100}",
+          "type": "borderWidth"
+        },
         "error": {
           "value": "{basic.borderWidth.100}",
           "type": "borderWidth"
@@ -197,6 +201,36 @@
           },
           "helper": {
             "value": "{theme.color.common.onSurfaceTertiary}",
+            "type": "color"
+          }
+        },
+        "read-only": {
+          "background": {
+            "value": "{theme.color.common.surface}",
+            "type": "color"
+          },
+          "leading-icon": {
+            "value": "{theme.color.common.onSurfaceTertiary}",
+            "type": "color"
+          },
+          "trailing-icon": {
+            "value": "{theme.color.common.onSurfaceTertiary}",
+            "type": "color"
+          },
+          "outline": {
+            "value": "{theme.color.common.separator}",
+            "type": "color"
+          },
+          "text": {
+            "value": "{theme.color.common.onSurfacePrimary}",
+            "type": "color"
+          },
+          "label": {
+            "value": "{theme.color.common.onSurfaceSecondary}",
+            "type": "color"
+          },
+          "helper": {
+            "value": "{theme.color.common.onSurfaceSecondary}",
             "type": "color"
           }
         },


### PR DESCRIPTION
## Summary
- Adds a `read-only` state to `tokens_2/Component/Settle/Input/Outlined.json`
- Label and value colors match the Default state
- Outline and both leading/trailing icons are dimmed
- Implements the `text field` portion of [Read-only state for form components](https://linear.app/settle/project/read-only-state-for-form-components-9fb4825a507d/overview) (STL-4026 / STL-4027)

## Test plan
- [x] Valid JSON, matches existing token conventions in the file
- [x] Pull branch into Figma via Tokens Studio and verify visually