### PR TITLE
Upgrade GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -57,6 +57,14 @@ jobs:
           node-version: 24.x
           cache: pnpm
 
+      # Written user-level because pnpm ignores auth settings in a repo .npmrc.
+      - name: Authenticate to GitHub Packages
+        env:
+          NPM_RC: ${{ secrets.NPM_RC }}
+        run: |
+          test -n "$NPM_RC" || { echo "::error::NPM_RC secret is not set"; exit 1; }
+          printf '%s\n' "$NPM_RC" >> ~/.npmrc
+
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find Comment
-        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -23,7 +23,7 @@ jobs:
           body-includes: Preview Deployment
 
       - name: Comment PR
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         id: comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -37,22 +37,22 @@ jobs:
           edit-mode: replace
 
       - name: Checkout web repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
             repository: ${{ secrets.WEB_REPO }}
             ref: main
             token: ${{ secrets.BOT_PAT }}
 
       - name: Checkout self
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: ${{ github.event.repository.name }}
 
       - name: Set pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24.x
           cache: pnpm
@@ -72,7 +72,7 @@ jobs:
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Update Comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.comment.outputs.comment-id }}
           body: |
@@ -89,7 +89,7 @@ jobs:
           NODE_OPTIONS: "--max_old_space_size=4096"
 
       - name: Update Comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.comment.outputs.comment-id }}
           body: |
@@ -104,7 +104,7 @@ jobs:
         id: deploy
         run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
 
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         id: get-deployment-url
         with:
           github-token: ${{ secrets.BOT_PAT }}
@@ -133,7 +133,7 @@ jobs:
             }
 
       - name: Update Comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.comment.outputs.comment-id }}
           body: |


### PR DESCRIPTION
Every action in `preview.yml` was on the deprecated **node20** runtime. Bumps all six:

| Action | From | To |
| --- | --- | --- |
| actions/checkout | v4 (×2) | v7 |
| actions/setup-node | v4 | v7 |
| actions/github-script | v7 | v9 |
| pnpm/action-setup | v4.1.0 | v6.0.10 |
| peter-evans/find-comment | v3.1.0 | v4.0.0 |
| peter-evans/create-or-update-comment | v4.0.0 (×4) | v5.0.0 |

SHA-pinned actions stay SHA-pinned, with the tag comment updated alongside.

Reviewer notes on the majors we're jumping:

- **github-script v9 has real breaking changes**: `require('@actions/github')` no longer works (the package is ESM-only now), and `getOctokit` became an injected parameter, so a script declaring `const getOctokit` throws a SyntaxError. Our inline script uses only `fetch` and `core.setOutput`, so neither applies.
- **peter-evans v4/v5 are node24-only rebuilds** — no input or output changes, so the `comment-id` wiring between the find/create/update steps is untouched.
- **pnpm/action-setup v6 is the first major with pnpm 11 support**, which is what the web repo's `packageManager` pins.
- `setup-node` keeps `node-version: 24.x` rather than `node-version-file` — this repo has no `package.json` to read from.

The workflow runs on `pull_request`, so this PR exercises the whole chain end to end: the three comment steps, both checkouts, the token build, and the Vercel preview deploy.

Contributes to [STL-5142](https://linear.app/settle/issue/STL-5142)